### PR TITLE
Enable passing weight_dir to models

### DIFF
--- a/ImmuneBuilder/ABodyBuilder2.py
+++ b/ImmuneBuilder/ABodyBuilder2.py
@@ -4,7 +4,7 @@ import os
 import sys
 import argparse
 from ImmuneBuilder.models import StructureModule
-from ImmuneBuilder.util import get_encoding, to_pdb, find_alignment_transform, download_file, sequence_dict_from_fasta, add_errors_as_bfactors
+from ImmuneBuilder.util import get_encoding, to_pdb, find_alignment_transform, download_file, sequence_dict_from_fasta, add_errors_as_bfactors, are_weights_ready
 from ImmuneBuilder.refine import refine
 from ImmuneBuilder.sequence_checks import number_sequences
 
@@ -86,21 +86,19 @@ class Antibody:
 
 
 class ABodyBuilder2:
-    def __init__(self, model_ids = [1,2,3,4]):
+    def __init__(self, model_ids = [1,2,3,4], weights_dir=None):
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        current_directory = os.path.dirname(os.path.realpath(__file__))
+        if weights_dir is None:
+            weights_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "trained_model")
 
         self.models = {}
         for id in model_ids:
             model_file = f"antibody_model_{id}"
             model = StructureModule(rel_pos_dim=64, embed_dim=embed_dim[model_file]).to(self.device)
-            weights_path = os.path.join(current_directory, "trained_model", model_file)
+            weights_path = os.path.join(weights_dir, model_file)
 
             try:
-                with open(weights_path, "rb") as f:
-                    filestart = str(f.readline())
-
-                if filestart == "b'EMPTY'":
+                if not are_weights_ready(weights_path):
                     print(f"Downloading weights for {model_file}...", flush=True)
                     download_file(model_urls[model_file], weights_path)
 

--- a/ImmuneBuilder/TCRBuilder2.py
+++ b/ImmuneBuilder/TCRBuilder2.py
@@ -4,7 +4,7 @@ import os
 import sys
 import argparse
 from ImmuneBuilder.models import StructureModule
-from ImmuneBuilder.util import get_encoding, to_pdb, find_alignment_transform, download_file, sequence_dict_from_fasta, add_errors_as_bfactors
+from ImmuneBuilder.util import get_encoding, to_pdb, find_alignment_transform, download_file, sequence_dict_from_fasta, add_errors_as_bfactors, are_weights_ready
 from ImmuneBuilder.refine import refine
 from ImmuneBuilder.sequence_checks import number_sequences
 
@@ -86,21 +86,19 @@ class TCR:
 
 
 class TCRBuilder2:
-    def __init__(self, model_ids = [1,2,3,4]):
+    def __init__(self, model_ids = [1,2,3,4], weights_dir=None):
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        current_directory = os.path.dirname(os.path.realpath(__file__))
+        if weights_dir is None:
+            weights_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "trained_model")
 
         self.models = {}
         for id in model_ids:
             model_file = f"tcr_model_{id}"
             model = StructureModule(rel_pos_dim=64, embed_dim=embed_dim[model_file]).to(self.device)
-            weights_path = os.path.join(current_directory, "trained_model", model_file)
+            weights_path = os.path.join(weights_dir, model_file)
 
             try:
-                with open(weights_path, "rb") as f:
-                    filestart = str(f.readline())
-
-                if filestart == "b'EMPTY'":
+                if not are_weights_ready(weights_path):
                     print(f"Downloading weights for {model_file}...", flush=True)
                     download_file(model_urls[model_file], weights_path)
 

--- a/ImmuneBuilder/util.py
+++ b/ImmuneBuilder/util.py
@@ -3,6 +3,7 @@ from ImmuneBuilder.constants import res_to_num, atom_types, residue_atoms, resty
 import numpy as np
 import torch
 import requests
+import os
 
 
 def download_file(url, filename):
@@ -124,3 +125,11 @@ def add_errors_as_bfactors(filename, errors, new_txt=[]):
 
     with open(filename, "w+") as file:
         file.writelines(new_txt)
+
+
+def are_weights_ready(weights_path):
+    if not os.path.exists(weights_path):
+        return False
+    with open(weights_path, "rb") as f:
+        filestart = str(f.readline())
+    return filestart != "b'EMPTY'"


### PR DESCRIPTION
Enable passing `weight_dir` to model constructor:

```python
ABodyBuilder2(weights_dir='/my/custom/dir')
```

This way we can reuse downloaded weights across python environments and handle cases when python env directory is not writable by current user.