### PR TITLE
Add cmd-line option for numbering schemes

### DIFF
--- a/ImmuneBuilder/ABodyBuilder2.py
+++ b/ImmuneBuilder/ABodyBuilder2.py
@@ -138,7 +138,7 @@ def command_line_interface():
         Supervisor: Charlotte Deane                           || 
     """
 
-    schemes = ('kabat','aho','wolfguy','imgt','a','c','chothia','i','k','m','w','martin')
+    schemes = ('imgt','chothia','kabat','aho','wolfguy','martin')
     parser = argparse.ArgumentParser(prog="ABodyBuilder2", description=description, formatter_class=argparse.RawDescriptionHelpFormatter)
 
     parser.add_argument("-H", "--heavy_sequence", help="Heavy chain amino acid sequence", default=None)
@@ -148,9 +148,7 @@ def command_line_interface():
     parser.add_argument("-o", "--output", help="Path to where the output model should be saved. Defaults to the same directory as input file.", default=None)
     parser.add_argument("--to_directory", help="Save all unrefined models and the top ranked refined model to a directory. " 
     "If this flag is set the output argument will be assumed to be a directory", default=False, action="store_true")
-    parser.add_argument("-n", "--numbering_scheme", help="The numbering scheme used for output antibody structures. i, k, c, m, w"
-                                                         " and a are shorthand for IMGT, Kabat, Chothia, Martin (Extended Chothia), Wolfguy and Aho respectively."
-                                                         " Default is IMGT", default='imgt', choices=schemes)
+    parser.add_argument("-n", "--numbering_scheme", help="The scheme used to number output antibody structures. Available numbering schemes are: imgt, chothia, kabat, aho, wolfguy and martin. Default is imgt.", default='imgt')
     parser.add_argument("-v", "--verbose", help="Verbose output", default=False, action="store_true")
 
     args = parser.parse_args()

--- a/ImmuneBuilder/ABodyBuilder2.py
+++ b/ImmuneBuilder/ABodyBuilder2.py
@@ -150,7 +150,7 @@ def command_line_interface():
     "If this flag is set the output argument will be assumed to be a directory", default=False, action="store_true")
     parser.add_argument("-n", "--numbering_scheme", help="The numbering scheme used for output antibody structures.  Options are" + ",".join(schemes) + " i, k, c, m, w"
                                                          " and a are shorthand for IMGT, Kabat, Chothia, Martin (Extended Chothia), Wolfguy and Aho respectively."
-                                                         " Default is IMGT", default='imgt', options=schemes)
+                                                         " Default is IMGT", default='imgt', choices=schemes)
     parser.add_argument("-v", "--verbose", help="Verbose output", default=False, action="store_true")
 
     args = parser.parse_args()

--- a/ImmuneBuilder/ABodyBuilder2.py
+++ b/ImmuneBuilder/ABodyBuilder2.py
@@ -138,6 +138,7 @@ def command_line_interface():
         Supervisor: Charlotte Deane                           || 
     """
 
+    schemes = ('kabat','aho','wolfguy','imgt','a','c','chothia','i','k','m','w','martin')
     parser = argparse.ArgumentParser(prog="ABodyBuilder2", description=description, formatter_class=argparse.RawDescriptionHelpFormatter)
 
     parser.add_argument("-H", "--heavy_sequence", help="Heavy chain amino acid sequence", default=None)
@@ -147,6 +148,9 @@ def command_line_interface():
     parser.add_argument("-o", "--output", help="Path to where the output model should be saved. Defaults to the same directory as input file.", default=None)
     parser.add_argument("--to_directory", help="Save all unrefined models and the top ranked refined model to a directory. " 
     "If this flag is set the output argument will be assumed to be a directory", default=False, action="store_true")
+    parser.add_argument("-n", "--numbering_scheme", help="The numbering scheme used for output antibody structures.  Options are" + ",".join(schemes) + " i, k, c, m, w"
+                                                         " and a are shorthand for IMGT, Kabat, Chothia, Martin (Extended Chothia), Wolfguy and Aho respectively."
+                                                         " Default is IMGT", default='imgt', options=schemes)
     parser.add_argument("-v", "--verbose", help="Verbose output", default=False, action="store_true")
 
     args = parser.parse_args()
@@ -165,7 +169,7 @@ def command_line_interface():
         print("Running sequences through deep learning model...", flush=True)
 
     try:
-        antibody = ABodyBuilder2().predict(seqs)
+        antibody = ABodyBuilder2(numbering_scheme=args.numbering_scheme).predict(seqs)
     except AssertionError as e:
         print(e, flush=True)
         sys.exit(1)

--- a/ImmuneBuilder/ABodyBuilder2.py
+++ b/ImmuneBuilder/ABodyBuilder2.py
@@ -148,7 +148,7 @@ def command_line_interface():
     parser.add_argument("-o", "--output", help="Path to where the output model should be saved. Defaults to the same directory as input file.", default=None)
     parser.add_argument("--to_directory", help="Save all unrefined models and the top ranked refined model to a directory. " 
     "If this flag is set the output argument will be assumed to be a directory", default=False, action="store_true")
-    parser.add_argument("-n", "--numbering_scheme", help="The numbering scheme used for output antibody structures.  Options are" + ",".join(schemes) + " i, k, c, m, w"
+    parser.add_argument("-n", "--numbering_scheme", help="The numbering scheme used for output antibody structures. i, k, c, m, w"
                                                          " and a are shorthand for IMGT, Kabat, Chothia, Martin (Extended Chothia), Wolfguy and Aho respectively."
                                                          " Default is IMGT", default='imgt', choices=schemes)
     parser.add_argument("-v", "--verbose", help="Verbose output", default=False, action="store_true")

--- a/ImmuneBuilder/NanoBodyBuilder2.py
+++ b/ImmuneBuilder/NanoBodyBuilder2.py
@@ -149,6 +149,8 @@ def command_line_interface():
     parser.add_argument("-o", "--output", help="Path to where the output model should be saved. Defaults to the same directory as input file.", default=None)
     parser.add_argument("--to_directory", help="Save all unrefined models and the top ranked refined model to a directory. " 
     "If this flag is set the output argument will be assumed to be a directory", default=False, action="store_true")
+    parser.add_argument("-n", "--numbering_scheme", help="The scheme used to number output nanobody structures. Available numbering schemes are: imgt, chothia, kabat, aho, wolfguy and martin. Default is imgt.", default='imgt')
+
     parser.add_argument("-v", "--verbose", help="Verbose output", default=False, action="store_true")
 
     args = parser.parse_args()
@@ -167,7 +169,7 @@ def command_line_interface():
         print("Running sequence through deep learning model...", flush=True)
 
     try:
-        antibody = NanoBodyBuilder2().predict(seqs)
+        antibody = NanoBodyBuilder2(numbering_scheme=args.numbering_scheme).predict(seqs)
     except AssertionError as e:
         print(e, flush=True)
         sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='ImmuneBuilder',
-    version='0.0.6',
+    version='0.0.7',
     description='Set of functions to predict the structure of immune receptor proteins',
     license='BSD 3-clause license',
     maintainer='Brennan Abanades',


### PR DESCRIPTION
This PR adds a passthrough argparse option for numbering schemes.  Since this functionality was already part of the main class, this PR is fairly simple.  It has been tested locally and confirmed to work. 