### PR TITLE
Fix raw numbering key error

### DIFF
--- a/ImmuneBuilder/sequence_checks.py
+++ b/ImmuneBuilder/sequence_checks.py
@@ -4,7 +4,8 @@ def number_single_sequence(sequence, chain, scheme="imgt", allowed_species=['hum
     validate_sequence(sequence)
 
     try:
-        scheme = scheme_short_to_long[scheme.lower()]
+        if scheme != "raw":
+            scheme = scheme_short_to_long[scheme.lower()]
     except KeyError:
         raise NotImplementedError(f"Unimplemented numbering scheme: {scheme}")
 


### PR DESCRIPTION
@brennanaba I just tried using `raw` numbering in the `pypi` version and I see there is a bug here:

https://github.com/oxpig/ImmuneBuilder/blob/main/ImmuneBuilder/sequence_checks.py#L6-L9

Causing this error:
```
Traceback (most recent call last):
  File "/scratch/prihodad/ImmuneBuilder/ImmuneBuilder/sequence_checks.py", line 7, in number_single_sequence
    scheme = scheme_short_to_long[scheme.lower()]
KeyError: 'raw'
```

I checked that this applies also for the github version. I prepared this bug fix.
